### PR TITLE
Remove remaining reference to g++-10

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -640,7 +640,7 @@ function build_bindings(; path::String=joinpath(libpoplar_dir, "libpoplar_julia.
 
     if compile
         cxxwrap_include_dir = joinpath(libcxxwrap_julia_jll.artifact_dir, "include")
-        cxx = get(ENV, "CXX", "g++-10")
+        cxx = get(ENV, "CXX", "g++")
         julia_include_dir = joinpath(dirname(Sys.BINDIR), "include", "julia")
         mkpath(dirname(path))
         run(```

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -34,7 +34,7 @@ DefaultBindgenContext() = DefaultBindgenContext([], [], Set([]), Set([]), "", ""
 
 
 function get_system_includes()::Vector{String}
-    cxx = get(ENV, "CXX", "g++-10")
+    cxx = get(ENV, "CXX", "g++")
     io = IOBuffer()
     readchomp(pipeline(`$(cxx) -x c++ -E -Wp,-v - -fsyntax-only`; stdin=IOBuffer(""), stderr=io))
     m = match(r"#include <\.\.\.> search starts here:(.*)End of search list\."s, String(take!(io)))[1]


### PR DESCRIPTION
It appears I messed up last time (see https://github.com/JuliaIPU/IPUToolkit.jl/pull/17) and there was another reference to `g++-10` elsewhere in `build.jl`.

Sorry!