### PR TITLE
Build the libpoplar wrapper in CI

### DIFF
--- a/.github/workflows/build_libpoplar.yml
+++ b/.github/workflows/build_libpoplar.yml
@@ -1,0 +1,58 @@
+name: Build libpoplar wrapper
+
+on:
+  push:
+    branches: "main"
+    tags: ["*"]
+  pull_request:
+  release:
+
+jobs:
+  build-libpoplar:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_image: graphcore/poplar:3.2.0-ubuntu-20.04-20230314
+    steps:
+      - name: "Install, g++, jq"
+        # g++ is needed to build the wrapper, jq for
+        # the `julia-actions/cache` workflow
+        run: |
+          apt-get update -y
+          apt-get install -y g++ jq
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.7"
+      - uses: julia-actions/cache@v1
+      - name: Instantiate wrapper generation environment
+        working-directory: ${{ github.workspace }}/deps
+        run: |
+          julia --project=. --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
+      - name: Generate source code of libpoplar wrapper
+        working-directory: ${{ github.workspace }}/deps
+        shell: julia --project=. --color=yes {0}
+        run: |
+          include(joinpath(pwd(), "generate_wrapper.jl"))
+          generate_wrapper()
+        env:
+          CXX: g++
+      - name: Instantiate build environment
+        working-directory: ${{ github.workspace }}/deps/bb_recipe
+        run: |
+          julia --project=. --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
+      - name: Compile libpoplar wrapper
+        working-directory: ${{ github.workspace }}/deps/bb_recipe
+        run: |
+          julia --project=. --color=yes build_tarballs.jl --verbose
+      - uses: actions/upload-artifact@v4
+        with:
+          name: products
+          path: ${{ github.workspace }}/deps/bb_recipe/products

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: "main"
     tags: ["*"]
-  pull_request:
+  # pull_request:
   release:
 
 # Note: ideally we'd have one job for running the tests and another for building

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,0 +1,16 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
+
+[compat]
+Clang = "0.14, 0.17.4"
+JSON = "0.21.4"
+Pkg = "1"
+Scratch = "1.1"
+UUIDs = "1"
+libcxxwrap_julia_jll = "0.11"
+julia = "1.7"

--- a/deps/bb_recipe/Project.toml
+++ b/deps/bb_recipe/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/deps/bb_recipe/build_tarballs.jl
+++ b/deps/bb_recipe/build_tarballs.jl
@@ -1,0 +1,58 @@
+using BinaryBuilder
+using Pkg
+
+name = "libpoplar_wrapper"
+version = v"1.0"
+
+# `POPLAR_SDK_ENABLED` should point to where the Poplar SDK is installed,
+# otherwise fallback to `/opt/poplar` (default dir in Graphcore Docker
+# containers).
+poplar_dir = get(ENV, "POPLAR_SDK_ENABLED", "/opt/poplar")
+
+sources = [
+    # The generated wrappers
+    DirectorySource("../wrapper"),
+    DirectorySource(dirname(poplar_dir)),
+]
+
+script = "POPLAR_DIR=$(basename(poplar_dir))\n" * raw"""
+cd ${WORKSPACE}/srcdir/
+
+mkdir -p "${libdir}"
+
+c++ \
+    -O0 \
+    -std=c++17 \
+    -fPIC \
+    -shared \
+    -I${POPLAR_DIR}/include \
+    -I${includedir} \
+    -I${includedir}/julia \
+    -I. \
+    -o "${libdir}/libpoplar_julia.${dlext}" \
+    template.cpp \
+    -L${POPLAR_DIR}/lib \
+    -L${libdir} \
+    -lpopops \
+    -lpoplar \
+    -lcxxwrap_julia \
+    -ljulia
+
+install_license /usr/share/licenses/MIT
+"""
+
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi="cxx11", julia_version="1.10.0"),
+]
+
+products = [
+    LibraryProduct("libpoplar_julia", :libpoplar_julia; dont_dlopen=true),
+]
+
+dependencies = [
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.9")),
+    Dependency("libcxxwrap_julia_jll"; compat = "~0.11.2"),
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.9", preferred_gcc_version=v"10", dont_dlopen=true)


### PR DESCRIPTION
Continuation of #37.

Proof of concept for #18.

Still lots to do:

* [x] the resulting library is only 21 kB, it's definitely wrong, it should be over ~40 MB, investigate what's the problem (resolved: I missed to pass the input file `template.cpp` to the compiler, so it was building an empty library.  Now I have some compilation errors, but it's good, it means it's trying to actually compile the right file)
* [x] fix compilation errors emerging after fixing the above point (was missing `-I{includedir}/julia`
* [x] link libjulia and libcxxwrap
* [ ] augment platform to build different wrappers for each SDK version, and the julia version
* [ ] provide method to build wrapper locally
* [ ] remove from project of the main package redundant dependencies that are needed only to build the wrapper
* [ ] require julia v1.9
* [ ] write documentation