### PR TITLE
Add an internal function to compile a codelet from LLVM IR as string

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IPUToolkit"
 uuid = "92e0b95a-4011-435a-96f4-10064551ddbe"
 authors = ["Emily Dietrich <jakibaki@live.com>", "Luk Burchard <luk.burchard@gmail.com>", "Mosè Giordano <mose@gnu.org>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"


### PR DESCRIPTION
This is marginally helping with #23 in the sense that the (***internal***) function `___build_codelet` takes the path of the generated codelet as input argument, and there's a method to skip the addition to the graph.  The next step for solving that issue would be to expose a function which does only the code generation + compilation, without adding anything to the graph.