### PR TITLE
Do not pirate `Base.rand`/`Base.randn` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IPUToolkit"
 uuid = "92e0b95a-4011-435a-96f4-10064551ddbe"
 authors = ["Emily Dietrich <jakibaki@live.com>", "Luk Burchard <luk.burchard@gmail.com>", "Mosè Giordano <mose@gnu.org>"]
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"


### PR DESCRIPTION
I forgot to use `@device_override` for these methods.