### PR TITLE
Revert "Temporarily cap EnzymeCore to v0.8.8"

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -10,5 +9,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Enzyme = "0.11, 0.12, 0.13"
-EnzymeCore = "0.7, 0.8 - 0.8.8"
 StaticArrays = "1"


### PR DESCRIPTION
This reverts commit 5ee799200b53c4c60a36d9737c0a74c0cce4795e.  Resolved upstream by https://github.com/JuliaRegistries/General/pull/137682.