### PR TITLE
Compile with C++20 standard

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,7 +27,7 @@ function build_bindings(; path::String=joinpath(libpoplar_dir, "libpoplar_julia.
         run(```
             $(cxx)
             -O0
-            -std=c++17
+            -std=c++20
             -fPIC
             -shared
             -I$(julia_include_dir)


### PR DESCRIPTION
cxxwrap seems to require C++20 now:
```
In file included from /github/home/.julia/artifacts/c74f464ba08d47b17764bb8c69c43b8213993c45/include/jlcxx/type_conversion.hpp:18,
                 from /github/home/.julia/artifacts/c74f464ba08d47b17764bb8c69c43b8213993c45/include/jlcxx/array.hpp:4,
                 from /github/home/.julia/artifacts/c74f464ba08d47b17764bb8c69c43b8213993c45/include/jlcxx/jlcxx.hpp:14,
                 from /__w/IPUToolkit.jl/IPUToolkit.jl/deps/wrapper/template.cpp:1:
/github/home/.julia/artifacts/c74f464ba08d47b17764bb8c69c43b8213993c45/include/jlcxx/jlcxx_config.hpp:22:2: error: #error "This library requires at least C++20"
   22 | #error "This library requires at least C++20"
      |  ^~~~~
```